### PR TITLE
解决文章标题中包含+、/、&等特殊字符时，使用google translate 会报error 403的问题

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -71,7 +71,7 @@ let google_translation = async function (data, fromLanguage, toLanguage, is_need
     data.translate_title = '';//初始化
     // console.log("原始data:"+postStr);
     let title = data.title;
-    let encodedStr = encodeURI(title);
+    let encodedStr = encodeURIComponent(title);
     let googleTransUrl = "https://translate.google.cn/translate_a/t?";
     googleTransUrl += "client=" + "t";
     googleTransUrl += "&sl=" + fromLanguage;// source   language
@@ -130,7 +130,7 @@ let youdao_translation = async function (data, youdao_api_key, youdao_keyfrom) {
     let ori_translate_title = data.translate_title;//先保存原来的翻译标题
     data.translate_title = '';//初始化
     let title = data.title;
-    let encodedStr = encodeURI(title);
+    let encodedStr = encodeURIComponent(title);
     let youdaoTransUrl = "http://fanyi.youdao.com/openapi.do?keyfrom=" + youdao_keyfrom;
     youdaoTransUrl += "&key=" + youdao_api_key;
     youdaoTransUrl += "&type=data&doctype=json&version=1.1&q=" + encodedStr;
@@ -177,7 +177,7 @@ let baidu_translation_with_appid = async function (data,fromLanguage,toLanguage,
     let ori_translate_title = data.translate_title;//先保存原来的翻译标题
     data.translate_title = '';//初始化
     let query_title = data.title;
-    let encodedStr = encodeURI(query_title);
+    let encodedStr = encodeURIComponent(query_title);
     // 多个query可以用\n连接  如 query='apple\norange\nbanana\npear'
     let str1 = appid + query_title + salt +appkey;
     let sign = lib_baidu_trans.baidu_trans_md5(str1);


### PR DESCRIPTION
如 [issue](https://github.com/cometlj/hexo-translate-title/issues/16) 中提到的，本人也遇到了文章标题中含特殊字符时，使用google translate 返回状态码错误，同时不能generate html文件。

原因是调用 google translate api 时对文章标题编码使用的是 **encodeURI** 方法，该方法中将 
``` * ;  ,  /  ? : @ & = + $ ```
等字符视作保留字符，不进行编码，因此会被google translate 拒绝访问。

解决办法是使用 **encodeURIComponent** 代替 **encodeURI**，前者会对除字母、数字、(、)、.、!、~、*、'、-和 _ 之外的所有字符进行转义。替换后问题解决，可以正常使用google translate翻译标题，并生成html 文件。

encodeURI 和 encodeURIComponent 的区别在于前者被设计来用于对完整URL进行URL Encode，URL中的功能字符比如&, ?, /, =等等不会被转义；而后者被设计来对URL中的某个值进行转义，会把这些功能字符也进行转义。
translate_title 作为调用google translate api 时 query 的一部分，此处使用 encodeURIComponent 也更合理。
